### PR TITLE
Fix BCD conversion shift overwriting add-3 adjustment

### DIFF
--- a/hex_to_dec_converter.srcs/sources_1/new/bin_to_bcd.v
+++ b/hex_to_dec_converter.srcs/sources_1/new/bin_to_bcd.v
@@ -24,7 +24,8 @@ module bin_to_bcd #(
     reg [IN_WIDTH-1:0] shift_reg;   // Holds binary bits yet to be processed
     reg [DIGITS*4-1:0] bcd_reg;     // Holds intermediate and final BCD digits
     reg [CNT_W-1:0]    cnt;         // Counts remaining bits to process
-    
+    reg [DIGITS*4-1:0] bcd_tmp;     // Temporary for add-3 adjustment
+
     integer d; //loop
     
     always @(posedge clk or negedge rst_n) begin
@@ -35,24 +36,26 @@ module bin_to_bcd #(
             done_o <= 1'b0; //default
             // Start conversion if active and idle
             if (start_i && !busy_o) begin
-                busy_o <= 1'b1;
+                busy_o   <= 1'b1;
                 shift_reg <= bin_i;
-                bcd_reg <= {DIGITS*4{1'b0}};
-                cnt <= IN_WIDTH[CNT_W-1:0];
-             // Main Conversion process
+                bcd_reg  <= {DIGITS*4{1'b0}};
+                cnt      <= IN_WIDTH[CNT_W-1:0];
+            // Main Conversion process
             end else if (busy_o) begin
+                // Perform add-3 adjustment on each digit before shifting
+                bcd_tmp = bcd_reg;
                 for (d = 0; d < DIGITS; d = d + 1) begin
-                    if (bcd_reg[d*4 +: 4] >= 5)
-                        bcd_reg[d*4 +: 4] <= bcd_reg[d*4 +: 4] + 4'd3;
+                    if (bcd_tmp[d*4 +: 4] >= 5)
+                        bcd_tmp[d*4 +: 4] = bcd_tmp[d*4 +: 4] + 4'd3;
                 end
-                bcd_reg   <= {bcd_reg[DIGITS*4-2:0], shift_reg[IN_WIDTH-1]};
+                bcd_reg   <= {bcd_tmp[DIGITS*4-2:0], shift_reg[IN_WIDTH-1]};
                 shift_reg <= {shift_reg[IN_WIDTH-2:0], 1'b0};
                 cnt <= cnt - 1'b1;
                 // If all bits processed, finish conversion
-                if (cnt == 0) begin
+                if (cnt == 1) begin
                     busy_o <= 1'b0;
                     done_o <= 1'b1;
-                    bcd_o  <= bcd_reg;
+                    bcd_o  <= {bcd_tmp[DIGITS*4-2:0], shift_reg[IN_WIDTH-1]};
                 end
             end
         end


### PR DESCRIPTION
## Summary
- prevent bin_to_bcd shift stage from clobbering add-3 updates by using a temporary register
- stop conversion after the final bit by checking when only one bit remains

## Testing
- `iverilog -o sim.out hex_to_dec_converter.srcs/sources_1/new/*.v && vvp sim.out` *(fails: command not found)*
- `apt-get install -y iverilog` *(fails: Unable to locate package iverilog)*

------
https://chatgpt.com/codex/tasks/task_e_68a140bfffb483218be9e75884a15be8